### PR TITLE
Hack tab-highlight-shifting on Chromium

### DIFF
--- a/manifest-chromium.json
+++ b/manifest-chromium.json
@@ -4,8 +4,6 @@
 	"description": "Navigate quickly with configurable commands",
 	"version": "0.0.0",
 
-	"browser_specific_settings": { "gecko": { "id": "navigator@ator-dev" } },
-
 	"icons": {
 		"48": "/icons/navigator.svg",
 		"96": "/icons/navigator.svg"
@@ -14,6 +12,7 @@
 	"permissions": [
 		"scripting",
 		"tabs",
+		"tabGroups",
 		"storage",
 		"search",
 		"contextMenus"

--- a/pages/popup.html
+++ b/pages/popup.html
@@ -4,22 +4,7 @@
 		<meta charset="utf-8">
 	</head>
 	<body>
-		<script>
-			window["command"] = ""
-			onkeydown = event => {
-				if (event.key !== "Escape") {
-					event.preventDefault();
-				}
-				if (event.key.length === 1 && event.key !== " ") {
-					window["command"] += event.key;
-				}
-			};
-			//chrome.storage.onChanged.addListener((changes, areaName) => {
-			//	if (areaName === "local" && changes.popupClass) {
-			//		popupClass = changes.popupClass;
-			//	}
-			//});
-		</script>
+		<script src="/dist/command-input-start.js"></script>
 		<script src="/dist/command-input.js"></script>
 	</body>
 </html>

--- a/src/command-input-start.ts
+++ b/src/command-input-start.ts
@@ -1,0 +1,16 @@
+window["command"] = "";
+
+onkeydown = event => {
+	if (event.key !== "Escape") {
+		event.preventDefault();
+	}
+	if (event.key.length === 1 && event.key !== " ") {
+		window["command"] += event.key;
+	}
+};
+
+//chrome.storage.onChanged.addListener((changes, areaName) => {
+//	if (areaName === "local" && changes.popupClass) {
+//		popupClass = changes.popupClass;
+//	}
+//});


### PR DESCRIPTION
- Make Chromium tab-highlighting workaround which moves a single tab group, since normal highlighting also activates tabs
- Move fast-loading command input into separate file to not violate content security policy